### PR TITLE
Update node-support-table.md

### DIFF
--- a/gh-pages/partials/node-support-table.md
+++ b/gh-pages/partials/node-support-table.md
@@ -3,7 +3,7 @@
     | Release   | Status                       | End-of-Life  |
     | --------- | ---------------------------- | ------------ |
     | `^14.6.0` | :white_check_mark: Supported | `2023-04-30` |
-    | `^16.3.0` | :white_check_mark: Supported | `2024-04-30` |
+    | `^16.3.0` | :white_check_mark: Supported | `2024-09-11` |
     | `^18.0.0` | :white_check_mark: Supported | `2025-04-30` |
 
     ??? question "Status Definitions"


### PR DESCRIPTION
See: https://nodejs.org/en/blog/announcements/nodejs16-eol

> We are moving the End-of-Life date of Node.js 16 by seven months to coincide with the end of support of OpenSSL 1.1.1 on September 11th, 2023.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
